### PR TITLE
Prepare for rc releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ install:
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  - upload_or_check_non_existence ./recipe conda-forge --channel=rc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,4 +69,4 @@ build: off
 test_script:
     - "%CMD_IN_ENV% conda build recipe --quiet"
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main
+    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=rc

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -48,13 +48,13 @@ source run_conda_forge_build_setup
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=rc || exit 1
 
     set -x
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=rc || exit 1
 touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
+channels:
+  targets:
+    - [conda-forge, rc]


### PR DESCRIPTION
Change the upload location to use the `rc` label on the `conda-forge` channel when uploading packages.