### PR TITLE
Add two more PyMC members as maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,3 +59,5 @@ extra:
     - ericmjl
     - springcoil
     - twiecki
+    - fonnesbeck
+    - michaelosthege


### PR DESCRIPTION
This way we'll be quicker to approve/improve PRs.

@fonnesbeck I'm adding you, because after all you're the PyMC BDFL.