### PR TITLE
Add myself as maintainer and fix Python version for PyMC3 3.9.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ericmjl @fonnesbeck @michaelosthege @springcoil @twiecki
+* @ericmjl @fonnesbeck @maresb @michaelosthege @springcoil @twiecki

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Feedstock Maintainers
 
 * [@ericmjl](https://github.com/ericmjl/)
 * [@fonnesbeck](https://github.com/fonnesbeck/)
+* [@maresb](https://github.com/maresb/)
 * [@michaelosthege](https://github.com/michaelosthege/)
 * [@springcoil](https://github.com/springcoil/)
 * [@twiecki](https://github.com/twiecki/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.6.1
     - pip
   run:
-    - python >=3.6
+    - python >=3.6.1
     - theano >=1.0.4
     - numpy >=1.13.0
     - scipy >=0.18.1
@@ -29,6 +29,8 @@ requirements:
     - tqdm >=4.8.4
     - h5py >=2.7.0
     - typing-extensions >=3.7.4.3,<4
+    - contextvars
+    - dataclasses
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,16 @@ source:
   sha256: 918b0a8050643e2a9dd4d276dd163befded33608db4969828f2c32305135d3e0
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.6
     - pip
   run:
-    - python >=3.7
+    - python >=3.6
     - theano >=1.0.4
     - numpy >=1.13.0
     - scipy >=0.18.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,3 +62,4 @@ extra:
     - twiecki
     - fonnesbeck
     - michaelosthege
+    - maresb


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Looks like I got confused on my previous 3.9.2 commit, Python 3.6 is allowed after all. I fix that here, and add myself as maintainer.

By the way, I tested

```bash
mamba create --name pymc3-test -c conda-forge pymc3=3.8
```

and now I get a usable PyMC3 install with `arviz` `0.11.1`! :smiley: 