### PR TITLE
Rebuild 3.10.0 to fix missing geweke import

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.3" %}
+{% set version = "3.10.0" %}
 
 package:
   name: pymc3
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pymc3/pymc3-{{ version }}.tar.gz
-  sha256: abe046f5a5d0e5baee80b7c4bc0a4c218f61b517b62d77be4f89cf4784c27d78
+  sha256: 6a1461a6239758edb78f66d31b3975dce54b6e80f3938717524e5a17803cc32e
 
 build:
-  number: 2
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -19,15 +19,14 @@ requirements:
     - pip
   run:
     - python >=3.6.1
-    - theano >=1.0.5
-    - numpy >=1.13.0
-    - scipy >=0.18.1
     - arviz >=0.9.0,<0.11.2
+    - dill
     - fastprogress >=0.2.0
+    - numpy >=1.13.0
     - pandas >=0.18.0
     - patsy >=0.5.1
-    - tqdm >=4.8.4
-    - h5py >=2.7.0
+    - scipy >=0.18.1
+    - theano-pymc ==1.0.11
     - typing-extensions >=3.7.4.3,<4
     - contextvars
     - dataclasses


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes https://discourse.pymc.io/t/6818
<!--
Please add any other relevant info below:
-->
I'd like to rebuild the following versions in order to add `arviz<0.11.2` in order to resolve the `geweke` module problem.

* [X] v3.8
* [X] v3.9.1
* [X] v3.9.2
* [X] v3.9.3
* [X] v3.10.0

There is a problem with the feedstocks from `v3.8` to `v3.10.0` inclusive, relating to how `pymc3` depends on `arviz`. The problem is that `v0.11.2` of `arviz` removed `arviz.geweke` in https://github.com/arviz-devs/arviz/pull/1545. Unfortunately, the aforementioned `pymc3` versions import this module on initialization. This means that `pymc3` will be completely broken. The command `import pymc3` will fail.

Now let's say I run `mamba install -c conda-forge pymc3==3.10.10`. Then `mamba` will install that version of `pymc3`, plus the latest "compatible" versions of its dependencies. Namely, it will install a new version of `arviz` which is missing `geweke`.

I propose to fix this problem by sequentially revising the affected builds to include an upper limit on the `arviz` version, namely `<0.11.2`.

This PR is the fifth step of this process, namely rebuilding `v3.10.0`. Here are [the relevant changes to `meta.yaml` for this PR from the original 3.10.0 version](https://github.com/conda-forge/pymc3-feedstock/compare/90ffb33..b1c8bba#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9a).

I have additionally fixed the incorrect minimum versions for `python` in the original 3.10.0 feedstock.

