### PR TITLE
Remove Python 3.6 support for PyMC3 3.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,16 @@ source:
   sha256: 6a1461a6239758edb78f66d31b3975dce54b6e80f3938717524e5a17803cc32e
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python >=3.6.1
+    - python >=3.7
     - pip
   run:
-    - python >=3.6.1
+    - python >=3.7
     - arviz >=0.9.0,<0.11.2
     - dill
     - fastprogress >=0.2.0
@@ -28,8 +28,6 @@ requirements:
     - scipy >=0.18.1
     - theano-pymc ==1.0.11
     - typing-extensions >=3.7.4.3,<4
-    - contextvars
-    - dataclasses
 
 test:
   imports:


### PR DESCRIPTION
Python 3.6 requires contextvars which pins python <3.7, breaking
modern Python versions.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
