### PR TITLE
Remove Python 3.6 support for PyMC3 3.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.10.0" %}
+{% set version = "3.9.3" %}
 
 package:
   name: pymc3
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pymc3/pymc3-{{ version }}.tar.gz
-  sha256: 6a1461a6239758edb78f66d31b3975dce54b6e80f3938717524e5a17803cc32e
+  sha256: abe046f5a5d0e5baee80b7c4bc0a4c218f61b517b62d77be4f89cf4784c27d78
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -19,14 +19,15 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - arviz >=0.9.0,<0.11.2
-    - dill
-    - fastprogress >=0.2.0
+    - theano >=1.0.5
     - numpy >=1.13.0
+    - scipy >=0.18.1
+    - arviz >=0.9.0,<0.11.2
+    - fastprogress >=0.2.0
     - pandas >=0.18.0
     - patsy >=0.5.1
-    - scipy >=0.18.1
-    - theano-pymc ==1.0.11
+    - tqdm >=4.8.4
+    - h5py >=2.7.0
     - typing-extensions >=3.7.4.3,<4
 
 test:


### PR DESCRIPTION
Python 3.6 requires contextvars which pins python <3.7, breaking
modern Python versions.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
